### PR TITLE
Fix: Season Stats

### DIFF
--- a/src/components/AwardTracker.tsx
+++ b/src/components/AwardTracker.tsx
@@ -7,13 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Table } from '@/components/ui/table';
 import { capitalizeName } from '@/utils';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-
-interface Award {
-  id: number;
-  playerName: string;
-  awardName: string;
-  year: number;
-}
+import { Award } from '@/types/statTypes';
 
 const predefinedAwards = [
   "Heisman Trophy",

--- a/src/components/AwardTracker.tsx
+++ b/src/components/AwardTracker.tsx
@@ -27,7 +27,7 @@ const predefinedAwards = [
   "Lombardi Award",
   "Unitas Golden Arm Award", 
   "Best Defensive End",
-  "Best Interorior Lineman",
+  "Best Interior Lineman",
   "Best Tight End",
   "Broyles Award",
   "Best Linebacker",

--- a/src/components/RecruitingClassTracker.tsx
+++ b/src/components/RecruitingClassTracker.tsx
@@ -8,16 +8,7 @@ import { Table } from '@/components/ui/table';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import useLocalStorage from '@/hooks/useLocalStorage';
 import { capitalizeName } from '@/utils';
-
-interface Recruit {
-  id: number;
-  name: string;
-  stars: string;
-  position: string;
-  rating: string;
-  potential: string;
-  recruitedYear: number;
-}
+import { Recruit } from '@/types/playerTypes';
 
 const positions = ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'];
 const potentials = ['Elite', 'Star', 'Impact', 'Normal'];

--- a/src/components/SchedulePage.tsx
+++ b/src/components/SchedulePage.tsx
@@ -138,7 +138,7 @@ const SchedulePage: React.FC = () => {
                       <SelectContent>
                         <SelectItem value="unselected">-- Select Team --</SelectItem>
                         <SelectItem key={'BYE'} value='BYE'>BYE</SelectItem>
-                        {fbsTeams.map(team => (
+                         {fbsTeams.map(team => (
                           <SelectItem key={team} value={team}>{team}</SelectItem>
                         ))}
                         {fcsTeams.map(team => (

--- a/src/components/SchedulePage.tsx
+++ b/src/components/SchedulePage.tsx
@@ -7,11 +7,12 @@ import { Input } from '@/components/ui/input';
 import { Table } from '@/components/ui/table';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
-import { getCurrentYear, getSchedule, setSchedule, Game, setYearStats, calculateStats, getYearStats } from '@/utils/localStorage';
+import { getCurrentYear, getSchedule, setSchedule, setYearStats, calculateStats, getYearStats } from '@/utils/localStorage';
 import { validateScore } from '@/utils/validationUtils';
 import { toast } from 'react-hot-toast';
 import { fbsTeams } from '@/utils/fbsTeams';
 import { fcsTeams } from '@/utils/fcsTeams';
+import { Game } from '@/types/yearRecord';
 
 const results = ['Win', 'Loss', 'Tie', 'Bye', 'N/A'] as const;
 const locations = ['@', 'vs', 'neutral', ' '] as const;

--- a/src/components/TeamHome.tsx
+++ b/src/components/TeamHome.tsx
@@ -6,10 +6,11 @@ import { useRouter } from 'next/navigation';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
-import { getCurrentYear, setCurrentYear, getSchedule, setSchedule, getYearStats, setYearStats, calculateStats, Game, YearStats } from '@/utils/localStorage';
+import { getCurrentYear, setCurrentYear, getSchedule, setSchedule, getYearStats, setYearStats, calculateStats, generateYearRecord, setYearRecord} from '@/utils/localStorage';
 import { validateYear } from '@/utils/validationUtils';
 import { toast } from 'react-hot-toast';
 import Link from 'next/link';
+import { Game, YearStats } from '@/types/yearRecord';
 
 const TeamHome: React.FC = () => {
   const router = useRouter();
@@ -50,30 +51,35 @@ const TeamHome: React.FC = () => {
   }, []);
 
   const endYear = () => {
-    if (!validateYear(currentYear + 1)) {
-      toast.error('Invalid next year. Please check the year and try again.');
+    if(!validateYear(currentYear + 1)) {
+      toast.error('Invalid next year. Please check year and try again')
       return;
     }
 
     try {
-      // Save current year's schedule and stats
+      // Save currentYear's schedules and stats
       setSchedule(currentYear, currentSchedule);
       const calculatedStats = calculateStats(currentSchedule);
       setYearStats(currentYear, calculatedStats);
-    
+
+      // Generate Year Record
+      let yearRecord = generateYearRecord(currentYear, yearStats, currentSchedule);
+
+      // Store Year Record
+      setYearRecord(currentYear, yearRecord);
+
       // Move to next year
       const newYear = currentYear + 1;
       setYear(newYear);
       setCurrentYear(newYear);
-      
-      // Reset schedule for new year
-      const newSchedule: Game[] = Array.from({ length: 19 }, (_, i) => ({ 
-        id: i, 
+
+      const newSchedule: Game[] = Array.from({ length:19 }, (_, i) => ({
+        id: i,
         week: i,
-        location: 'neutral', 
-        opponent: 'unselected', 
-        result: 'N/A', 
-        score: '' 
+        location: 'neutral',
+        opponent: 'unselected',
+        result: 'N/A',
+        score: ''
       }));
       setCurrentSchedule(newSchedule);
       setSchedule(newYear, newSchedule);
@@ -96,7 +102,7 @@ const TeamHome: React.FC = () => {
       console.error('Error ending year:', error);
       toast.error('Failed to end the year. Please try again.');
     }
-  };
+  }
 
   if (isLoading) {
     return <div>Loading...</div>;

--- a/src/components/TransferPortalTracker.tsx
+++ b/src/components/TransferPortalTracker.tsx
@@ -9,16 +9,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import useLocalStorage from '@/hooks/useLocalStorage';
 import { capitalizeName } from '@/utils';
 import { fbsTeams } from '@/utils/fbsTeams';
-
-interface Transfer {
-  id: number;
-  playerName: string;
-  position: string;
-  stars: string;
-  transferDirection: 'From' | 'To';
-  school: string;
-  transferYear: number;
-}
+import { Transfer } from '@/types/playerTypes';
+import { getTransfers } from '@/utils/localStorage';
 
 const positions = ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'];
 const starOptions = ['1', '2', '3', '4', '5'];
@@ -36,7 +28,7 @@ const TransferPortalTracker: React.FC = () => {
   const [editingId, setEditingId] = useState<number | null>(null);
   const [selectedYear, setSelectedYear] = useState<number>(currentYear);
 
-  const transfersForSelectedYear = allTransfers.filter(transfer => transfer.transferYear === selectedYear);
+  const transfersForSelectedYear = getTransfers(selectedYear);
 
   const addTransfer = () => {
     const transferToAdd = {

--- a/src/components/YearRecordModal.tsx
+++ b/src/components/YearRecordModal.tsx
@@ -9,61 +9,9 @@ import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table } from '@/components/ui/table';
 import { ScrollArea } from "@/components/ui/scroll-area";
-
-interface Game {
-  week: number;
-  opponent: string;
-  result: string;
-  score: string;
-}
-
-interface Recruit {
-  recruitedYear: number;
-  name: string;
-  stars: string;
-  position: string;
-  rating: string;
-  potential: string;
-}
-
-interface Transfer {
-  transferYear: number;
-  playerName: string;
-  position: string;
-  stars: string;
-  transferDirection: 'From' | 'To';
-  school: string;
-}
-
-interface YearRecord {
-  year: number;
-  overallRecord: string;
-  conferenceRecord: string;
-  bowlGame: string;
-  bowlResult: string;
-  pointsFor: string;
-  pointsAgainst: string;
-  natChamp: string;
-  heisman: string;
-  schedule?: Game[];
-  recruits?: Recruit[];
-  transfers?: Transfer[];
-  playerAwards: Award[];
-  recruitingClassPlacement: string;
-  playersDrafted: DraftedPlayer[];
-}
-
-interface Award {
-  id: number;
-  playerName: string;
-  awardName: string;
-  year: number;
-}
-
-interface DraftedPlayer {
-  playerName: string;
-  round: string;
-}
+import { DraftedPlayer, Recruit, Transfer } from '@/types/playerTypes';
+import { Award } from '@/types/statTypes';
+import { YearRecord, Game, YearStats } from '@/types/yearRecord';
 
 interface YearRecordModalProps {
   year: number;

--- a/src/components/YearRecordModal.tsx
+++ b/src/components/YearRecordModal.tsx
@@ -12,6 +12,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { DraftedPlayer, Recruit, Transfer } from '@/types/playerTypes';
 import { Award } from '@/types/statTypes';
 import { YearRecord, Game, YearStats } from '@/types/yearRecord';
+import { getRecruits, getTransfers, getYearAwards, getYearRecord } from '@/utils/localStorage';
 
 interface YearRecordModalProps {
   year: number;
@@ -38,40 +39,32 @@ const YearRecordModal: React.FC<YearRecordModalProps> = ({ year, onClose }) => {
   });
 
   useEffect(() => {
-    const storedRecords = localStorage.getItem('yearRecords');
-    const storedRecruits = localStorage.getItem(`allRecruits`);
-    const storedTransfers = localStorage.getItem(`allTransfers`);
-    const storedAwards = localStorage.getItem('allAwards');
+    let existingRecord = getYearRecord(year);
 
-    if (storedRecords) {
-      const records: YearRecord[] = JSON.parse(storedRecords);
-      const existingRecord = records.find(r => r.year === year);
-      if (existingRecord) {
-        setRecord({
-          ...existingRecord,
-          schedule: existingRecord.schedule || record.schedule,
-          playersDrafted: existingRecord.playersDrafted || [],
-        });
+    if(existingRecord.playerAwards.length == 0) {
+      const yearAwards = getYearAwards(year);
+      existingRecord = {
+        ...existingRecord, 
+        playerAwards: yearAwards
+      }
+    }
+    if(existingRecord.transfers?.length == 0) {
+      const yearTransfers = getTransfers(year);
+      existingRecord = {
+        ...existingRecord, 
+        transfers: yearTransfers
+      }
+    }
+    if(existingRecord.recruits?.length == 0) {
+      const yearRecruits = getRecruits(year);
+      existingRecord = {
+        ...existingRecord, 
+        recruits: yearRecruits
       }
     }
 
-    if (storedRecruits) {
-      const allRecruits: Recruit[] = JSON.parse(storedRecruits);
-      const yearRecruits = allRecruits.filter(recruit => recruit.recruitedYear === year);
-      setRecord(prev => ({ ...prev, recruits: yearRecruits }));
-    }
+    setRecord(existingRecord);
 
-    if (storedTransfers) {
-      const allTransfers: Transfer[] = JSON.parse(storedTransfers);
-      const yearTransfers = allTransfers.filter(transfer => transfer.transferYear === year);
-      setRecord(prev => ({ ...prev, transfers: yearTransfers }));
-    }
-
-    if (storedAwards) {
-      const allAwards: Award[] = JSON.parse(storedAwards);
-      const yearAwards = allAwards.filter(award => award.year === year);
-      setRecord(prev => ({ ...prev, playerAwards: yearAwards }));
-    }
   }, [year]);
 
   const handleSave = () => {

--- a/src/components/YearRecordModal.tsx
+++ b/src/components/YearRecordModal.tsx
@@ -78,13 +78,13 @@ const YearRecordModal: React.FC<YearRecordModalProps> = ({ year, onClose }) => {
     const storedRecords = localStorage.getItem('yearRecords');
     let records: YearRecord[] = storedRecords ? JSON.parse(storedRecords) : [];
     const existingIndex = records.findIndex(r => r.year === year);
-  
+
     if (existingIndex !== -1) {
       records[existingIndex] = record;
     } else {
       records.push(record);
     }
-  
+
     localStorage.setItem('yearRecords', JSON.stringify(records));
     onClose();
   };
@@ -206,14 +206,14 @@ const YearRecordModal: React.FC<YearRecordModalProps> = ({ year, onClose }) => {
                 </div>
               </div>
               <div className="grid grid-cols-3 items-center gap-4">
-                  <label htmlFor="classRanking" className="text-right">Recruiting Class Rank:</label>
-                  <Input
-                    id="classRanking"
-                    value={record.recruitingClassPlacement}
-                    onChange={(e) => setRecord({ ...record, recruitingClassPlacement: e.target.value })}
-                    className="col-span-2"
-                  />
-                </div>
+                <label htmlFor="classRanking" className="text-right">Recruiting Class Rank:</label>
+                <Input
+                  id="classRanking"
+                  value={record.recruitingClassPlacement}
+                  onChange={(e) => setRecord({ ...record, recruitingClassPlacement: e.target.value })}
+                  className="col-span-2"
+                />
+              </div>
             </ScrollArea>
           </div>
           {record.schedule && (
@@ -273,6 +273,23 @@ const YearRecordModal: React.FC<YearRecordModalProps> = ({ year, onClose }) => {
             <h3 className="text-xl text-center font-semibold mb-2">{year} Recruits, Transfers, and Awards</h3>
             <ScrollArea className="h-[calc(100%-3rem)] w-full rounded-md border p-4">
               <div className="space-y-4">
+                <h4 className="text-lg font-semibold text-center">Player Awards</h4>
+                <Table>
+                  <thead>
+                    <tr>
+                      <th>Player</th>
+                      <th>Award Name</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {record.playerAwards?.map((award, index) => (
+                      <tr key={index}>
+                        <td style={{ textAlign: 'center' }}>{award.playerName}</td>
+                        <td style={{ textAlign: 'center' }}>{award.awardName}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
                 <h4 className="text-lg font-semibold text-center">Recruits</h4>
                 <Table>
                   <thead>

--- a/src/types/playerTypes.ts
+++ b/src/types/playerTypes.ts
@@ -1,0 +1,30 @@
+export interface Player {
+    id: number;
+    name: string;
+    position: string;
+    year: string;
+    rating: string;
+}
+
+export interface Recruit {
+    recruitedYear: number;
+    name: string;
+    stars: string;
+    position: string;
+    rating: string;
+    potential: string;
+}
+
+export interface Transfer {
+    transferYear: number;
+    playerName: string;
+    position: string;
+    stars: string;
+    transferDirection: 'From' | 'To';
+    school: string;
+}
+
+export interface DraftedPlayer {
+    playerName: string;
+    round: string;
+}

--- a/src/types/playerTypes.ts
+++ b/src/types/playerTypes.ts
@@ -1,3 +1,5 @@
+// This file should contain types relating to a player's information (recruiting, roster, transfer, etc.)
+
 export interface Player {
     id: number;
     name: string;

--- a/src/types/playerTypes.ts
+++ b/src/types/playerTypes.ts
@@ -9,6 +9,7 @@ export interface Player {
 }
 
 export interface Recruit {
+    id: number,
     recruitedYear: number;
     name: string;
     stars: string;
@@ -18,6 +19,7 @@ export interface Recruit {
 }
 
 export interface Transfer {
+    id: number;
     transferYear: number;
     playerName: string;
     position: string;

--- a/src/types/statTypes.ts
+++ b/src/types/statTypes.ts
@@ -1,0 +1,6 @@
+export interface Award {
+    id: number;
+    playerName: string;
+    awardName: string;
+    year: number;
+  }

--- a/src/types/statTypes.ts
+++ b/src/types/statTypes.ts
@@ -1,3 +1,5 @@
+// This file should contain type definitions relating to player stats (either stat's themselves or awards)
+
 export interface Award {
     id: number;
     playerName: string;

--- a/src/types/yearRecord.ts
+++ b/src/types/yearRecord.ts
@@ -1,4 +1,5 @@
 // src/types/yearRecord.ts
+// This file should contain type definitions for types pertaining to year records (I.E stats, schedules, records)
 
 import { DraftedPlayer, Recruit, Transfer } from "./playerTypes";
 import { Award } from "./statTypes";
@@ -26,7 +27,7 @@ export interface YearStats {
   losses: number;
   conferenceWins: number;
   conferenceLosses: number;
-  pointsFor: number;
+  pointsScored: number;
   pointsAgainst: number;
   playersDrafted: number;
   conferenceStanding: string;

--- a/src/types/yearRecord.ts
+++ b/src/types/yearRecord.ts
@@ -2,16 +2,17 @@
 
 export interface YearRecord {
   year: number;
-  wins: number;
-  losses: number;
-  ties: number;
+  overallRecord: string;
+  conferenceRecord: string;
   confWins: number;
   confLosses: number;
   confTies: number;
   pointsFor: number;
   pointsAgainst: number;
   bowlGame: string;
-  bowlResult?: string;
+  bowlResult?: "W" | "L" | "N/A";
+  nationalChamp: string;
+  heismanWinner: string;
   bowlScore: { team: number; opponent: number };
   schedule: Game[];
   notes: string;

--- a/src/types/yearRecord.ts
+++ b/src/types/yearRecord.ts
@@ -1,29 +1,48 @@
 // src/types/yearRecord.ts
 
+import { DraftedPlayer, Recruit, Transfer } from "./playerTypes";
+import { Award } from "./statTypes";
+
 export interface YearRecord {
   year: number;
   overallRecord: string;
   conferenceRecord: string;
-  confWins: number;
-  confLosses: number;
-  confTies: number;
+  bowlGame: string;
+  bowlResult: string;
+  pointsFor: string;
+  pointsAgainst: string;
+  natChamp: string;
+  heisman: string;
+  schedule?: Game[];
+  recruits?: Recruit[];
+  transfers?: Transfer[];
+  playerAwards: Award[];
+  recruitingClassPlacement: string;
+  playersDrafted: DraftedPlayer[];
+}
+
+export interface YearStats {
+  wins: number;
+  losses: number;
+  conferenceWins: number;
+  conferenceLosses: number;
   pointsFor: number;
   pointsAgainst: number;
+  playersDrafted: number;
+  conferenceStanding: string;
   bowlGame: string;
-  bowlResult?: "W" | "L" | "N/A";
-  nationalChamp: string;
-  heismanWinner: string;
-  bowlScore: { team: number; opponent: number };
-  schedule: Game[];
-  notes: string;
+  bowlResult: 'Win' | 'Loss' | 'CFP' | 'DNP' | '';
 }
 
 export interface Game {
+  id: number;
+  week: number;
+  location: '@' | 'vs' | 'neutral' | ' ';
   opponent: string;
-  result: string;
-  score: { team: number; opponent: number };
+  result: 'Win' | 'Loss' | 'Tie' | 'Bye' | 'N/A';
+  score: string;
 }
-  
-  export type AllRecords = {
-    [year: number]: YearRecord;
-  };
+
+export type AllRecords = {
+  [year: number]: YearRecord;
+};

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -107,3 +107,4 @@ export const setYearStats = (year: number, stats: YearStats): void => {
   }
 };
 
+// TODO: Add Method to Generate and Save Year Record

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -126,7 +126,7 @@ export const getYearRecord = (year: number): YearRecord => {
     pointsAgainst: '',
     natChamp: '',
     heisman: '',
-    schedule: [],
+    schedule: Array(19).fill({ week: 0, opponent: '', result: '', score: '' }).map((game, index) => ({ ...game, week: index })),
     recruits: [],
     transfers: [],
     playerAwards: [],

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,26 +1,9 @@
 // utils/localStorage.ts
 
-export interface Game {
-  id: number;
-  week: number;
-  location: '@' | 'vs' | 'neutral' | ' ';
-  opponent: string;
-  result: 'Win' | 'Loss' | 'Tie' | 'Bye' | 'N/A';
-  score: string;
-}
-
-export interface YearStats {
-  wins: number;
-  losses: number;
-  conferenceWins: number;
-  conferenceLosses: number;
-  pointsScored: number;
-  pointsAgainst: number;
-  playersDrafted: number;
-  conferenceStanding: string;
-  bowlGame: string;
-  bowlResult: string;
-}
+import { Recruit, Transfer } from "@/types/playerTypes";
+import { Award } from "@/types/statTypes";
+import { Game, YearRecord, YearStats } from "@/types/yearRecord";
+import { stat } from "fs";
 
 export const getCurrentYear = (): number => {
   if (typeof window !== 'undefined') {
@@ -65,7 +48,7 @@ export const calculateStats = (schedule: Game[]): YearStats => {
       }
     }
   });
-  
+
   return {
     wins,
     losses,
@@ -106,5 +89,162 @@ export const setYearStats = (year: number, stats: YearStats): void => {
     localStorage.setItem(`yearStats_${year}`, JSON.stringify(stats));
   }
 };
+
+export const setYearRecord = (year: number, record: YearRecord): void => {
+  if (typeof window !== 'undefined') {
+    const storedRecords = localStorage.getItem('yearRecords');
+    let records: YearRecord[] = storedRecords ? JSON.parse(storedRecords) : [];
+    const existingIndex = records.findIndex(r => r.year === year);
+
+    if (existingIndex !== -1) {
+      records[existingIndex] = record;
+    } else {
+      records.push(record);
+    }
+
+    localStorage.setItem('yearRecords', JSON.stringify(records));
+  }
+}
+
+export const getYearRecord = (year: number): YearRecord => {
+  if (typeof window !== 'undefined') {
+    const storedRecords = localStorage.getItem('yearRecords');
+    let records: YearRecord[] = storedRecords ? JSON.parse(storedRecords) : [];
+    const existingIndex = records.findIndex(r => r.year === year);
+
+    if (existingIndex !== -1) {
+      return records[existingIndex]
+    }
+  }
+  return {
+    year: year,
+    overallRecord: '',
+    conferenceRecord: '',
+    bowlGame: '',
+    bowlResult: '',
+    pointsFor: '',
+    pointsAgainst: '',
+    natChamp: '',
+    heisman: '',
+    schedule: [],
+    recruits: [],
+    transfers: [],
+    playerAwards: [],
+    recruitingClassPlacement: '',
+    playersDrafted: []
+  }
+}
+
+/**
+ * Generates a {@link YearRecord} item for use with storage and saving
+ * @param year the year of the record being generated
+ * @param stats an element of type {@link YearStats} representing various statistics about the season
+ * @param schedule the season schedule of the year of the record
+ * @param natChamp the national champion of the year
+ * @param heisman the year's heisman winner
+ * @param classPlacement team's recruiting class rank for the given year
+ * @returns an item of type {@link YearRecord} containing the relevant data from the season
+ */
+export const generateYearRecord = (year: number, stats: YearStats, schedule: Game[], natChamp?: string, heisman?: string, classPlacement?: string): YearRecord => {
+  let ovrRecord = stats.wins + '-' + stats.losses;
+  let confRecord = stats.conferenceWins + '-' + stats.conferenceLosses;
+  let yearTransfers = getTransfers(year);
+  let yearRecruits = getRecruits(year);
+  return {
+    year: year,
+    overallRecord: ovrRecord,
+    conferenceRecord: confRecord,
+    bowlGame: stats.bowlGame,
+    bowlResult: stats.bowlResult,
+    pointsFor: String(stats.pointsScored),
+    pointsAgainst: String(stats.pointsAgainst),
+    natChamp: natChamp || '',
+    heisman: heisman || '',
+    schedule: schedule,
+    recruits: yearRecruits,
+    transfers: yearTransfers,
+    playerAwards: getYearAwards(year),
+    recruitingClassPlacement: classPlacement || '',
+    playersDrafted: []
+  }
+}
+
+export const getAllRecruits = (): Recruit[] => {
+  if (typeof window !== 'undefined') {
+    const storedRecruits = localStorage.getItem('allRecruits');
+    if (storedRecruits) {
+      const allRecruits: Recruit[] = JSON.parse(storedRecruits);
+      return allRecruits;
+    }
+  }
+  return [];
+}
+
+export const getRecruits = (year: number): Recruit[] => {
+  if (typeof window !== 'undefined') {
+    const storedRecruits = getAllRecruits();
+    if (storedRecruits.length !== 0) {
+      const yearRecruits = storedRecruits.filter(recruit => recruit.recruitedYear === year);
+      return yearRecruits;
+    }
+  }
+  return [];
+}
+
+export const setRecruits = (recruits: Recruit[]): void => {
+  if (typeof window !== 'undefined') {
+    const storedRecruits: Recruit[] = getAllRecruits();
+    let newList = storedRecruits.concat(recruits);
+    localStorage.setItem('allRecruits', JSON.stringify(newList));
+  }
+}
+
+export const getAllTransfers = (): Transfer[] => {
+  if (typeof window !== 'undefined') {
+    const storedTransfers = localStorage.getItem('allTransfers');
+    if (storedTransfers) {
+      const allTransfers: Transfer[] = JSON.parse(storedTransfers);
+      return allTransfers;
+    }
+  }
+  return [];
+}
+
+export const getTransfers = (year: number): Transfer[] => {
+  if(typeof window !== 'undefined') {
+    const allTransfers = getAllTransfers();
+    const yearTransfers = allTransfers.filter(transfer => transfer.transferYear === year);
+    return yearTransfers
+  }
+  return [];
+}
+
+export const setTransfers = (transfers: Transfer[]): void => {
+  if (typeof window !== 'undefined') {
+    const allTransfers: Transfer[] = getAllTransfers();
+    let newList = allTransfers.concat(transfers);
+    localStorage.setItem('allTransfers', JSON.stringify(newList));
+  }
+}
+
+export const getAllAwards = (): Award[] => {
+  if (typeof window !== 'undefined') {
+    const storedAwards = localStorage.getItem('allAwards');
+    if(storedAwards) {
+      const allAwards: Award[] = JSON.parse(storedAwards);
+      return allAwards;
+    }
+  }
+  return [];
+}
+
+export const getYearAwards = (year: number): Award[] => {
+  if(typeof window !== 'undefined') {
+    const allAwards = getAllAwards();
+    let yearAwards = allAwards.filter(award => award.year === year);
+    return yearAwards;
+  }
+  return [];
+}
 
 // TODO: Add Method to Generate and Save Year Record


### PR DESCRIPTION
Somewhere in the process (I assume adding the end year button to the dashboard) the season stats page seemed to break, I can only assume this is because of inconsistencies in the year record storage as perceived by the dashboard page and the year stats page. This fix makes sure both are using the same consistent definition of YearRecord and adds methods to LocalStorage to make sure of that

I also started moving types that are shared between multiple files into specific ts files, and importing them (I.E Game, YearStat, YearRecord, Recruit) this allows for ensuring that one source of truth is shared for those data, and should make it easier to make everything display the right data. 

I also added Awards to the year stat modal, so it displays the player awards for that year in the modal. 

This is a semi-big PR, I'm aware and I understand if it goes beyond use for you, so feel free to reject it, or make changes yourself hope it helps though. 