### PR TITLE
fix: saving extended positions (LG, LT, etc)

### DIFF
--- a/src/components/RecruitingClassTracker.tsx
+++ b/src/components/RecruitingClassTracker.tsx
@@ -9,8 +9,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import useLocalStorage from '@/hooks/useLocalStorage';
 import { capitalizeName } from '@/utils';
 import { Recruit } from '@/types/playerTypes';
+import { generalPositions } from '@/types/playerTypes';
 
-const positions = ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'];
 const potentials = ['Elite', 'Star', 'Impact', 'Normal'];
 const starOptions = ['1', '2', '3', '4', '5'];
 
@@ -115,7 +115,7 @@ const RecruitingClassTracker: React.FC = () => {
                 <SelectValue placeholder="Position" />
               </SelectTrigger>
               <SelectContent>
-                {positions.map(pos => (
+                {generalPositions.map(pos => (
                   <SelectItem key={pos} value={pos}>{pos}</SelectItem>
                 ))}
               </SelectContent>

--- a/src/components/Roster.tsx
+++ b/src/components/Roster.tsx
@@ -11,6 +11,7 @@ import { capitalizeName } from '@/utils';
 import { validateName, validateRating, validatePosition } from '@/utils/validationUtils';
 import { toast } from 'react-hot-toast';
 import RosterImageUpload from './RosterImageUpload';
+import { positions } from '@/types/playerTypes';
 
 interface Player {
   id: number;
@@ -22,7 +23,6 @@ interface Player {
   notes: string;
 }
 
-const positions = ['QB', 'RB', 'FB', 'WR', 'TE', 'LT', 'LG', 'C', 'RG', 'RT', 'LE', 'RE', 'DT', 'LOLB', 'MLB', 'ROLB', 'CB', 'FS', 'SS', 'K', 'P'];
 const years = ['FR', 'FR (RS)', 'SO', 'SO (RS)', 'JR', 'JR (RS)', 'SR', 'SR (RS)'];
 const devTraits = ['Normal', 'Impact', 'Star', 'Elite'] as const;
 

--- a/src/components/TransferPortalTracker.tsx
+++ b/src/components/TransferPortalTracker.tsx
@@ -11,9 +11,8 @@ import { capitalizeName } from '@/utils';
 import { fbsTeams } from '@/utils/fbsTeams';
 import { Transfer } from '@/types/playerTypes';
 import { getTransfers } from '@/utils/localStorage';
+import { generalPositions } from '@/types/playerTypes';
 
-
-const positions = ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'];
 const starOptions = ['1', '2', '3', '4', '5'];
 
 const TransferPortalTracker: React.FC = () => {
@@ -140,7 +139,7 @@ const TransferPortalTracker: React.FC = () => {
                 <SelectValue placeholder="Position" />
               </SelectTrigger>
               <SelectContent>
-                {positions.map(pos => (
+                {generalPositions.map(pos => (
                   <SelectItem key={pos} value={pos}>{pos}</SelectItem>
                 ))}
               </SelectContent>

--- a/src/types/playerTypes.ts
+++ b/src/types/playerTypes.ts
@@ -1,4 +1,6 @@
 // This file should contain types relating to a player's information (recruiting, roster, transfer, etc.)
+export const positions = ['QB', 'RB', 'FB', 'WR', 'TE', 'LT', 'LG', 'C', 'RG', 'RT', 'LE', 'RE', 'DT', 'LOLB', 'MLB', 'ROLB', 'CB', 'FS', 'SS', 'K', 'P'];
+export const generalPositions = ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P', 'ATH'];
 
 export interface Player {
     id: number;

--- a/src/utils/validationUtils.ts
+++ b/src/utils/validationUtils.ts
@@ -1,4 +1,5 @@
 // src/utils/validationUtils.ts
+import { positions } from "@/types/playerTypes";
 
 export const validateScore = (score: string): boolean => {
     // Score should be in the format "0-0" or "00-00" or "000-000"
@@ -21,6 +22,5 @@ export const validateScore = (score: string): boolean => {
   };
   
   export const validatePosition = (position: string): boolean => {
-    const validPositions = ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'];
-    return validPositions.includes(position);
+    return positions.includes(position);
   };


### PR DESCRIPTION
Makes sure that the user can save players to rosters using the extended positions, and moves the position definitions to the playerType.js files (one should be used when specifics are needed LOLB, RT) the other is just for generals (Lineman).

